### PR TITLE
RE-194 feat: implement ReminderBatchJob for dynamic reminder scheduling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM gradle:8.5-jdk17 AS builder
 WORKDIR /app
 COPY . .
-RUN gradle build -x test
+RUN gradle build --continue
 
 # Run stage
 FROM amazoncorretto:17-alpine3.20

--- a/src/main/java/info/reinput/reinput_notification_service/notification/batch/ReminderBatchJob.java
+++ b/src/main/java/info/reinput/reinput_notification_service/notification/batch/ReminderBatchJob.java
@@ -1,0 +1,94 @@
+package info.reinput.reinput_notification_service.notification.batch;
+
+import info.reinput.reinput_notification_service.notification.domain.ReminderSchedule;
+import info.reinput.reinput_notification_service.notification.domain.ReminderType;
+import info.reinput.reinput_notification_service.notification.infra.ReminderRepository;
+import info.reinput.reinput_notification_service.notification.infra.ReminderScheduleRepository;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.format.TextStyle;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+public class ReminderBatchJob implements Job {
+
+    private static final Logger log = LoggerFactory.getLogger(ReminderBatchJob.class);
+
+    // Quartz Job은 스프링 빈이 아니므로, JobDataMap을 통해 주입 받거나, 스프링에서 지원하는 방식 사용
+    // 여기서는 생성자 주입으로 가정 (설정에 따라 QuartzJobBean을 상속하거나 JobFactory를 설정할 수 있음)
+    private final ReminderRepository reminderRepository;
+    private final ReminderScheduleRepository reminderScheduleRepository;
+
+    public ReminderBatchJob(ReminderRepository reminderRepository, ReminderScheduleRepository reminderScheduleRepository) {
+        this.reminderRepository = reminderRepository;
+        this.reminderScheduleRepository = reminderScheduleRepository;
+    }
+    
+    @Override
+    @Transactional
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        log.info("ReminderBatchJob 시작");
+
+        // 오늘 날짜 계산 (시간은 제외)
+        LocalDate today = LocalDate.now();
+        
+        // 오늘의 Monthly 타입: 예) "Monthly_30"
+        String monthlyTypeName = "Monthly_" + today.getDayOfMonth();
+        
+        // 오늘의 Weekly 타입: 예) "Weekly_Mon"
+        // java.time.DayOfWeek에서 MONDAY를 "Mon"으로 변환
+        DayOfWeek dayOfWeek = today.getDayOfWeek();
+        String dayShort = dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.ENGLISH);
+        // displayName "Mon", "Tue", ... 유지
+        String weeklyTypeName = "Weekly_" + dayShort;
+        
+        log.info("오늘의 날짜: {}", today);
+        log.info("오늘의 Monthly 타입: {}", monthlyTypeName);
+        log.info("오늘의 Weekly 타입: {}", weeklyTypeName);
+        
+        // todayReminders를 담을 HashSet
+        Set<Long> todayReminders = new HashSet<>();
+        
+        List<ReminderSchedule> schedules = reminderScheduleRepository.findAll();
+        log.info("ReminderSchedule 레코드 총 {}개 조회됨.", schedules.size());
+        
+        for (ReminderSchedule rs : schedules) {
+            ReminderType type = rs.getReminderType();
+            // 조건 2.a: 오늘 타입과 일치하는 경우
+            if(type.name().equals(monthlyTypeName) || type.name().equals(weeklyTypeName)) {
+                todayReminders.add(rs.getReminder().getId());
+            }
+            // 조건 2.b: Recommended 타입인 경우
+            if(type == ReminderType.Recommended) {
+                LocalDate createdDate = rs.getCreatedAt().toLocalDate();
+                long daysDiff = java.time.temporal.ChronoUnit.DAYS.between(createdDate, today);
+                if(daysDiff == 1 || daysDiff == 7 || daysDiff == 30) {
+                    todayReminders.add(rs.getReminder().getId());
+                }
+            }
+        }
+        log.info("오늘 리마인드 대상 reminder id 개수: {}", todayReminders.size());
+        
+        // 3단계: 모든 reminder의 isToday를 false로 초기화 후, 대상 reminder의 isToday를 true로 업데이트
+        reminderRepository.resetTodayReminder();
+        log.info("모든 reminder의 isToday 플래그를 false로 초기화함.");
+        
+        if (!todayReminders.isEmpty()){
+            reminderRepository.updateTodayReminders(todayReminders);
+            log.info("reminder id {} 에 대해 isToday 플래그를 true로 업데이트함.", todayReminders);
+        } else {
+            log.info("업데이트할 reminder가 없습니다.");
+        }
+        
+        log.info("ReminderBatchJob 작업 완료됨.");
+    }
+} 

--- a/src/main/java/info/reinput/reinput_notification_service/notification/domain/ReminderSchedule.java
+++ b/src/main/java/info/reinput/reinput_notification_service/notification/domain/ReminderSchedule.java
@@ -23,15 +23,11 @@ public class ReminderSchedule {
     @Enumerated(EnumType.STRING)
     private ReminderType reminderType;
 
-    private LocalDateTime updatedAt;
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
 
     @PrePersist
     protected void onCreate() {
-        updatedAt = LocalDateTime.now();
-    }
-
-    @PreUpdate
-    protected void onUpdate() {
-        updatedAt = LocalDateTime.now();
+        createdAt = LocalDateTime.now();
     }
 } 

--- a/src/main/java/info/reinput/reinput_notification_service/notification/domain/ReminderType.java
+++ b/src/main/java/info/reinput/reinput_notification_service/notification/domain/ReminderType.java
@@ -5,15 +5,15 @@ import lombok.Getter;
 @Getter
 public enum ReminderType {
     // Monthly types (매월 1일 ~ 31일)
-    Monthly_01("0 0 0 1 * ?"),
-    Monthly_02("0 0 0 2 * ?"),
-    Monthly_03("0 0 0 3 * ?"),
-    Monthly_04("0 0 0 4 * ?"),
-    Monthly_05("0 0 0 5 * ?"),
-    Monthly_06("0 0 0 6 * ?"),
-    Monthly_07("0 0 0 7 * ?"),
-    Monthly_08("0 0 0 8 * ?"),
-    Monthly_09("0 0 0 9 * ?"),
+    Monthly_1("0 0 0 1 * ?"),
+    Monthly_2("0 0 0 2 * ?"),
+    Monthly_3("0 0 0 3 * ?"),
+    Monthly_4("0 0 0 4 * ?"),
+    Monthly_5("0 0 0 5 * ?"),
+    Monthly_6("0 0 0 6 * ?"),
+    Monthly_7("0 0 0 7 * ?"),
+    Monthly_8("0 0 0 8 * ?"),
+    Monthly_9("0 0 0 9 * ?"),
     Monthly_10("0 0 0 10 * ?"),
     Monthly_11("0 0 0 11 * ?"),
     Monthly_12("0 0 0 12 * ?"),
@@ -38,13 +38,13 @@ public enum ReminderType {
     Monthly_31("0 0 0 31 * ?"),
 
     // Weekly types (매주 월~일)
-    Weekly_Mon("0 0 0 ? * MON"),
-    Weekly_Tue("0 0 0 ? * TUE"),
-    Weekly_Wed("0 0 0 ? * WED"),
-    Weekly_Thu("0 0 0 ? * THU"),
-    Weekly_Fri("0 0 0 ? * FRI"),
-    Weekly_Sat("0 0 0 ? * SAT"),
-    Weekly_Sun("0 0 0 ? * SUN"),
+    Weekly_Mon("0 0 0 ? * Mon"),
+    Weekly_Tue("0 0 0 ? * Tue"),
+    Weekly_Wed("0 0 0 ? * Wed"),
+    Weekly_Thu("0 0 0 ? * Thu"),
+    Weekly_Fri("0 0 0 ? * Fri"),
+    Weekly_Sat("0 0 0 ? * Sat"),
+    Weekly_Sun("0 0 0 ? * Sun"),
 
     // Recommended type (망각곡선)
     Recommended("0 0 0 * * ?");  // 매일 실행되며, 로직에서 날짜 차이 계산

--- a/src/main/java/info/reinput/reinput_notification_service/notification/infra/ReminderRepository.java
+++ b/src/main/java/info/reinput/reinput_notification_service/notification/infra/ReminderRepository.java
@@ -2,7 +2,23 @@ package info.reinput.reinput_notification_service.notification.infra;
 
 import info.reinput.reinput_notification_service.notification.domain.Reminder;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface ReminderRepository extends JpaRepository<Reminder, Long> {
     boolean existsByInsightId(Long insightId);
+    
+    // 모든 reminder의 isToday 플래그를 false로 변경
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("update Reminder r set r.isToday = false")
+    void resetTodayReminder();
+    
+    // 특정 reminder id set에 해당하는 reminder의 isToday 플래그를 true로 변경
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("update Reminder r set r.isToday = true where r.id in :ids")
+    void updateTodayReminders(@Param("ids") java.util.Set<Long> ids);
 } 

--- a/src/test/java/info/reinput/reinput_notification_service/notification/batch/ReminderBatchJobTest.java
+++ b/src/test/java/info/reinput/reinput_notification_service/notification/batch/ReminderBatchJobTest.java
@@ -1,0 +1,134 @@
+package info.reinput.reinput_notification_service.notification.batch;
+
+import info.reinput.reinput_notification_service.notification.domain.Reminder;
+import info.reinput.reinput_notification_service.notification.domain.ReminderSchedule;
+import info.reinput.reinput_notification_service.notification.domain.ReminderType;
+import info.reinput.reinput_notification_service.notification.infra.ReminderRepository;
+import info.reinput.reinput_notification_service.notification.infra.ReminderScheduleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.DayOfWeek;
+import java.time.format.TextStyle;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ReminderBatchJobTest {
+
+    @Mock
+    private ReminderRepository reminderRepository;
+
+    @Mock
+    private ReminderScheduleRepository reminderScheduleRepository;
+
+    @Mock
+    private JobExecutionContext jobExecutionContext;
+
+    private ReminderBatchJob reminderBatchJob;
+
+    @BeforeEach
+    public void setUp() {
+        reminderBatchJob = new ReminderBatchJob(reminderRepository, reminderScheduleRepository);
+    }
+
+    @Test
+    public void testReminderBatchJob_AllCases() throws JobExecutionException {
+        System.out.println("테스트 시작: ReminderBatchJob 모든 케이스 테스트");
+        // 고정된 날짜: 2025-02-01 (토요일)
+        LocalDate fixedDate = LocalDate.of(2025, 2, 1);
+        System.out.println("테스트 날짜 설정: " + fixedDate);
+        LocalDateTime fixedDateTime = fixedDate.atStartOfDay(); // 비교에 사용
+
+        // 예상되는 타입
+        String expectedMonthlyType = "Monthly_" + fixedDate.getDayOfMonth();  // Monthly_1
+        DayOfWeek day = fixedDate.getDayOfWeek();
+        String dayShort = day.getDisplayName(TextStyle.SHORT, Locale.ENGLISH);
+        String expectedWeeklyType = "Weekly_" + dayShort;                    // Weekly_Sat
+
+        // 테스트용 Reminder와 ReminderSchedule 객체 생성 (id값은 임의로 설정)
+        Reminder reminder1 = Reminder.builder().id(1L).insightId(1L).isActive(true).build(); // Monthly_1
+        Reminder reminder2 = Reminder.builder().id(2L).insightId(2L).isActive(true).build(); // Weekly_Sat
+        Reminder reminder3 = Reminder.builder().id(3L).insightId(3L).isActive(true).build(); // Recommended, createdAt = 어제 (차이 1일)
+        Reminder reminder4 = Reminder.builder().id(4L).insightId(4L).isActive(true).build(); // Recommended, createdAt 차이 2일 (미해당)
+        Reminder reminder5 = Reminder.builder().id(5L).insightId(5L).isActive(true).build(); // Monthly_5 (미일치)
+
+        // ReminderSchedule 목록 준비
+        List<ReminderSchedule> scheduleList = new ArrayList<>();
+        // 1. 타입이 Monthly_10 -> 조건 2.a
+        scheduleList.add(ReminderSchedule.builder()
+                .id(101L)
+                .reminder(reminder1)
+                .reminderType(ReminderType.valueOf(expectedMonthlyType))
+                .createdAt(fixedDateTime)
+                .build());
+        // 2. 타입이 Weekly_Tue -> 조건 2.a
+        scheduleList.add(ReminderSchedule.builder()
+                .id(102L)
+                .reminder(reminder2)
+                .reminderType(ReminderType.valueOf(expectedWeeklyType))
+                .createdAt(fixedDateTime)
+                .build());
+        // 3. Recommended 타입, createdAt = 어제 -> 조건 2.b (차이 1일)
+        scheduleList.add(ReminderSchedule.builder()
+                .id(103L)
+                .reminder(reminder3)
+                .reminderType(ReminderType.Recommended)
+                .createdAt(fixedDateTime.minusDays(1))
+                .build());
+        // 4. Recommended 타입, createdAt = fixedDate.minusDays(2) -> 차이가 2일, 업데이트 대상이 아님
+        scheduleList.add(ReminderSchedule.builder()
+                .id(104L)
+                .reminder(reminder4)
+                .reminderType(ReminderType.Recommended)
+                .createdAt(fixedDateTime.minusDays(2))
+                .build());
+        // 5. Monthly_5 -> 타입 불일치 (fixedDate의 일자가 1이므로)
+        scheduleList.add(ReminderSchedule.builder()
+                .id(105L)
+                .reminder(reminder5)
+                .reminderType(ReminderType.Monthly_5)
+                .createdAt(fixedDateTime)
+                .build());
+
+        // ReminderScheduleRepository에서 findAll() 호출시 위 스케줄 목록을 반환
+        when(reminderScheduleRepository.findAll()).thenReturn(scheduleList);
+
+        // static mocking을 통해 LocalDate.now() 반환값을 고정
+        try (MockedStatic<LocalDate> mockedLocalDate = Mockito.mockStatic(LocalDate.class, CALLS_REAL_METHODS)) {
+            mockedLocalDate.when(LocalDate::now).thenReturn(fixedDate);
+
+            // execute() 메서드 실행
+            reminderBatchJob.execute(jobExecutionContext);
+        }
+
+        // 예상 대상 reminder id: reminder1 (id=1), reminder2 (id=2), reminder3 (id=3)
+        Set<Long> expectedIds = new HashSet<>();
+        expectedIds.add(1L);
+        expectedIds.add(2L);
+        expectedIds.add(3L);
+
+        // resetTodayReminder() 호출 Verifiy
+        verify(reminderRepository, times(1)).resetTodayReminder();
+        // updateTodayReminders()가 위의 expectedIds와 함께 호출되는지 확인
+        verify(reminderRepository, times(1)).updateTodayReminders(expectedIds);
+
+        System.out.println("ReminderBatchJob 실행 완료");
+        System.out.println("예상되는 업데이트 대상 ID: " + expectedIds);
+        System.out.println("테스트 종료");
+    }
+} 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,7 @@
+spring:
+  cloud:
+    discovery:
+      enabled: false
+eureka:
+  client:
+    enabled: false 


### PR DESCRIPTION
- Add ReminderBatchJob to handle daily reminder scheduling based on Monthly, Weekly, and Recommended types
- Update ReminderSchedule to use createdAt instead of updatedAt
- Modify ReminderType to use single-digit monthly types and short day names
- Extend ReminderRepository with methods to reset and update reminder's isToday flag
- Add comprehensive test for ReminderBatchJob covering various scheduling scenarios

---
close [RE-194]

[RE-194]: https://reinput.atlassian.net/browse/RE-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ