### PR TITLE
RE-198 feat: modify reminder creation to replace existing reminders

### DIFF
--- a/src/main/java/info/reinput/reinput_notification_service/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/info/reinput/reinput_notification_service/global/exception/GlobalExceptionHandler.java
@@ -1,7 +1,6 @@
 package info.reinput.reinput_notification_service.global.exception;
 
 import info.reinput.reinput_notification_service.global.dto.ErrorResponse;
-import info.reinput.reinput_notification_service.notification.exception.DuplicateInsightException;
 import info.reinput.reinput_notification_service.notification.exception.InvalidReminderRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,16 +16,6 @@ import io.swagger.v3.oas.annotations.Hidden;
     basePackageClasses = {ReminderController.class}
 )
 public class GlobalExceptionHandler {
-
-    @Hidden
-    @ExceptionHandler(DuplicateInsightException.class)
-    public ResponseEntity<ErrorResponse> handleDuplicateInsightException(DuplicateInsightException e) {
-        ErrorResponse response = ErrorResponse.builder()
-                .message(e.getMessage())
-                .code("DUPLICATE_INSIGHT")
-                .build();
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
-    }
 
     @Hidden
     @ExceptionHandler(InvalidReminderRequestException.class)

--- a/src/main/java/info/reinput/reinput_notification_service/notification/exception/DuplicateInsightException.java
+++ b/src/main/java/info/reinput/reinput_notification_service/notification/exception/DuplicateInsightException.java
@@ -1,7 +1,0 @@
-package info.reinput.reinput_notification_service.notification.exception;
-
-public class DuplicateInsightException extends RuntimeException {
-    public DuplicateInsightException(String message) {
-        super(message);
-    }
-} 

--- a/src/main/java/info/reinput/reinput_notification_service/notification/infra/ReminderRepository.java
+++ b/src/main/java/info/reinput/reinput_notification_service/notification/infra/ReminderRepository.java
@@ -6,9 +6,12 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
+import java.util.Optional;
 
 public interface ReminderRepository extends JpaRepository<Reminder, Long> {
     boolean existsByInsightId(Long insightId);
+    
+    Optional<Reminder> findByInsightId(Long insightId);
     
     // 모든 reminder의 isToday 플래그를 false로 변경
     @Modifying(clearAutomatically = true)

--- a/src/main/java/info/reinput/reinput_notification_service/notification/infra/ReminderScheduleRepository.java
+++ b/src/main/java/info/reinput/reinput_notification_service/notification/infra/ReminderScheduleRepository.java
@@ -1,7 +1,9 @@
 package info.reinput.reinput_notification_service.notification.infra;
 
 import info.reinput.reinput_notification_service.notification.domain.ReminderSchedule;
+import info.reinput.reinput_notification_service.notification.domain.Reminder;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReminderScheduleRepository extends JpaRepository<ReminderSchedule, Long> {
+    void deleteAllByReminder(Reminder reminder);
 } 


### PR DESCRIPTION
- Remove DuplicateInsightException and related handler
- Update ReminderServiceImpl to delete existing reminder and schedules when creating a new reminder for the same insight
- Add findByInsightId method to ReminderRepository
- Add deleteAllByReminder method to ReminderScheduleRepository
- Change ReminderController endpoint from POST to PATCH to reflect upsert behavior
- Update API documentation to clarify new reminder creation/modification logic

close [RE-198]