### PR TITLE
RE-212 feat: add reminder detail retrieval and enhance error handling

### DIFF
--- a/src/main/java/info/reinput/reinput_notification_service/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/info/reinput/reinput_notification_service/global/exception/GlobalExceptionHandler.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.bind.annotation.RestController;
 import info.reinput.reinput_notification_service.notification.presentation.ReminderController;
 import io.swagger.v3.oas.annotations.Hidden;
+import info.reinput.reinput_notification_service.notification.exception.ReminderNotFoundException;
+import info.reinput.reinput_notification_service.notification.exception.InvalidReminderTypeException;
 
 @Hidden
 @RestControllerAdvice(
@@ -35,5 +37,25 @@ public class GlobalExceptionHandler {
                 .code("INTERNAL_SERVER_ERROR")
                 .build();
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+
+    @Hidden
+    @ExceptionHandler(ReminderNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleReminderNotFoundException(ReminderNotFoundException e) {
+        ErrorResponse response = ErrorResponse.builder()
+                .message(e.getMessage())
+                .code("REMINDER_NOT_FOUND")
+                .build();
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    @Hidden
+    @ExceptionHandler(InvalidReminderTypeException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidReminderTypeException(InvalidReminderTypeException e) {
+        ErrorResponse response = ErrorResponse.builder()
+                .message(e.getMessage())
+                .code("INVALID_REMINDER_REQUEST")
+                .build();
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 } 

--- a/src/main/java/info/reinput/reinput_notification_service/notification/application/ReminderService.java
+++ b/src/main/java/info/reinput/reinput_notification_service/notification/application/ReminderService.java
@@ -2,7 +2,10 @@ package info.reinput.reinput_notification_service.notification.application;
 
 import info.reinput.reinput_notification_service.notification.presentation.dto.req.ReminderCreateReq;
 import info.reinput.reinput_notification_service.notification.presentation.dto.res.ReminderCreateRes;
+import info.reinput.reinput_notification_service.notification.presentation.dto.res.ReminderDetailRes;
 
 public interface ReminderService {
     ReminderCreateRes createReminder(ReminderCreateReq request);
+    
+    ReminderDetailRes getReminderDetail(Long insightId);
 } 

--- a/src/main/java/info/reinput/reinput_notification_service/notification/application/impl/ReminderServiceImpl.java
+++ b/src/main/java/info/reinput/reinput_notification_service/notification/application/impl/ReminderServiceImpl.java
@@ -3,22 +3,28 @@ package info.reinput.reinput_notification_service.notification.application.impl;
 import info.reinput.reinput_notification_service.notification.application.ReminderService;
 import info.reinput.reinput_notification_service.notification.domain.Reminder;
 import info.reinput.reinput_notification_service.notification.domain.ReminderSchedule;
+import info.reinput.reinput_notification_service.notification.domain.ReminderType;
 import info.reinput.reinput_notification_service.notification.infra.ReminderRepository;
 import info.reinput.reinput_notification_service.notification.infra.ReminderScheduleRepository;
 import info.reinput.reinput_notification_service.notification.presentation.dto.req.ReminderCreateReq;
 import info.reinput.reinput_notification_service.notification.presentation.dto.res.ReminderCreateRes;
+import info.reinput.reinput_notification_service.notification.presentation.dto.res.ReminderDetailRes;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import info.reinput.reinput_notification_service.notification.exception.InvalidReminderRequestException;
 import java.util.Optional;
+import java.util.List;
+import java.util.stream.Collectors;
+import info.reinput.reinput_notification_service.notification.exception.ReminderNotFoundException;
+import info.reinput.reinput_notification_service.notification.exception.InvalidReminderTypeException;
 
 @Service
 @RequiredArgsConstructor
 public class ReminderServiceImpl implements ReminderService {
     private final ReminderRepository reminderRepository;
     private final ReminderScheduleRepository reminderScheduleRepository;
-
+    
     @Override
     @Transactional
     public ReminderCreateRes createReminder(ReminderCreateReq request) {
@@ -31,7 +37,7 @@ public class ReminderServiceImpl implements ReminderService {
             // 기존 Reminder 삭제
             reminderRepository.delete(reminderToDelete);
         }
-
+        
         // isActive와 types 유효성 검증
         validateReminderRequest(request);
         
@@ -41,7 +47,7 @@ public class ReminderServiceImpl implements ReminderService {
                 .build();
         
         reminderRepository.save(reminder);
-
+        
         if (request.isActive()) {
             request.getTypes().forEach(type -> {
                 ReminderSchedule schedule = ReminderSchedule.builder()
@@ -51,19 +57,61 @@ public class ReminderServiceImpl implements ReminderService {
                 reminderScheduleRepository.save(schedule);
             });
         }
-
+        
         return ReminderCreateRes.builder()
                 .reminderId(reminder.getId())
                 .insightId(reminder.getInsightId())
                 .isActive(reminder.isActive())
                 .build();
     }
-
+    
+    @Override
+    @Transactional(readOnly = true)  // 조회만 하므로 readOnly = true 추가
+    public ReminderDetailRes getReminderDetail(Long insightId) {
+        Reminder reminder = reminderRepository.findByInsightId(insightId)
+            .orElseThrow(() -> new ReminderNotFoundException("해당 insightId에 대한 리마인더를 찾을 수 없습니다: " + insightId));
+        
+        if (!reminder.isActive()) {
+            // 비활성화된 리마인더는 types 없이 반환
+            return ReminderDetailRes.builder()
+                    .reminderId(reminder.getId())
+                    .insightId(reminder.getInsightId())
+                    .isActive(false)
+                    .build();
+        } else {
+            // 활성화된 리마인더인 경우, 관련 ReminderSchedule 조회
+            List<ReminderSchedule> schedules = reminderScheduleRepository.findByReminder(reminder);
+            
+            if (schedules.isEmpty()) {
+                throw new ReminderNotFoundException("활성화된 리마인더는 최소 하나 이상의 알림 스케줄이 존재해야 합니다.");
+            }
+            
+            List<ReminderType> types = schedules.stream()
+                    .map(ReminderSchedule::getReminderType)
+                    .collect(Collectors.toList());
+            
+            return ReminderDetailRes.builder()
+                    .reminderId(reminder.getId())
+                    .insightId(reminder.getInsightId())
+                    .isActive(true)
+                    .types(types)
+                    .build();
+        }
+    }
+    
     private void validateReminderRequest(ReminderCreateReq request) {
         if (request.isActive()) {
             if (request.getTypes() == null || request.getTypes().isEmpty()) {
                 throw new InvalidReminderRequestException("활성화된 리마인더는 반드시 알림 타입을 포함해야 합니다.");
             }
+            // ReminderType 유효성 검증 추가
+            request.getTypes().forEach(type -> {
+                try {
+                    ReminderType.valueOf(type.name());
+                } catch (IllegalArgumentException e) {
+                    throw new InvalidReminderTypeException("유효하지 않은 ReminderType입니다: " + type.name());
+                }
+            });
         } else {
             if (request.getTypes() != null && !request.getTypes().isEmpty()) {
                 throw new InvalidReminderRequestException("비활성화된 리마인더는 알림 타입을 포함할 수 없습니다.");

--- a/src/main/java/info/reinput/reinput_notification_service/notification/batch/QuartzConfig.java
+++ b/src/main/java/info/reinput/reinput_notification_service/notification/batch/QuartzConfig.java
@@ -26,31 +26,4 @@ public class QuartzConfig {
                         .inTimeZone(TimeZone.getTimeZone("Asia/Seoul")))
                 .build();
     }
-
-    /*
-* 문제상황: Timezone을 Asia/Seoul로 설정하였으나, 아래 로그에서는 2025-02-01T21:00:00.045Z 로 나오는 모습을 확인할 수 있음. 왜냐? 서버가 UTC를 쓰니까. 그럼 저 inTimeZone 설정이 무용지물이 되는거 아닌가?
-
-     * 2025-02-01T21:00:00.045Z  INFO 1 --- [reinput-notification-service] [eduler_Worker-1] i.r.r.n.batch.ReminderBatchJob           : ReminderBatchJob 시작
-2025-02-01T21:00:00.056Z  INFO 1 --- [reinput-notification-service] [eduler_Worker-1] i.r.r.n.batch.ReminderBatchJob           : 오늘의 날짜: 2025-02-01
-2025-02-01T21:00:00.057Z  INFO 1 --- [reinput-notification-service] [eduler_Worker-1] i.r.r.n.batch.ReminderBatchJob           : 오늘의 Monthly 타입: Monthly_1
-2025-02-01T21:00:00.057Z  INFO 1 --- [reinput-notification-service] [eduler_Worker-1] i.r.r.n.batch.ReminderBatchJob           : 오늘의 Weekly 타입: Weekly_Sat
-Hibernate: 
-    select
-        rs1_0.id,
-        rs1_0.created_at,
-        rs1_0.reminder_id,
-        rs1_0.reminder_type 
-    from
-        reminder_schedule rs1_0
-2025-02-01T21:00:00.304Z  INFO 1 --- [reinput-notification-service] [eduler_Worker-1] i.r.r.n.batch.ReminderBatchJob           : ReminderSchedule 레코드 총 0개 조회됨.
-2025-02-01T21:00:00.304Z  INFO 1 --- [reinput-notification-service] [eduler_Worker-1] i.r.r.n.batch.ReminderBatchJob           : 오늘 리마인드 대상 reminder id 개수: 0
-Hibernate: 
-    update
-        reminder r1_0 
-    set
-        is_today=0
-2025-02-01T21:00:00.533Z  INFO 1 --- [reinput-notification-service] [eduler_Worker-1] i.r.r.n.batch.ReminderBatchJob           : 모든 reminder의 isToday 플래그를 false로 초기화함.
-2025-02-01T21:00:00.533Z  INFO 1 --- [reinput-notification-service] [eduler_Worker-1] i.r.r.n.batch.ReminderBatchJob           : 업데이트할 reminder가 없습니다.
-2025-02-01T21:00:00.533Z  INFO 1 --- [reinput-notification-service] [eduler_Worker-1] i.r.r.n.batch.ReminderBatchJob           : ReminderBatchJob 작업 완료됨.
-     */
 }

--- a/src/main/java/info/reinput/reinput_notification_service/notification/domain/ReminderType.java
+++ b/src/main/java/info/reinput/reinput_notification_service/notification/domain/ReminderType.java
@@ -1,8 +1,10 @@
 package info.reinput.reinput_notification_service.notification.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
+@Schema
 public enum ReminderType {
     // Monthly types (매월 1일 ~ 31일)
     Monthly_1("0 0 0 1 * ?"),

--- a/src/main/java/info/reinput/reinput_notification_service/notification/exception/InvalidReminderTypeException.java
+++ b/src/main/java/info/reinput/reinput_notification_service/notification/exception/InvalidReminderTypeException.java
@@ -1,0 +1,7 @@
+package info.reinput.reinput_notification_service.notification.exception;
+
+public class InvalidReminderTypeException extends RuntimeException {
+    public InvalidReminderTypeException(String message) {
+        super(message);
+    }
+} 

--- a/src/main/java/info/reinput/reinput_notification_service/notification/exception/ReminderNotFoundException.java
+++ b/src/main/java/info/reinput/reinput_notification_service/notification/exception/ReminderNotFoundException.java
@@ -1,0 +1,7 @@
+package info.reinput.reinput_notification_service.notification.exception;
+
+public class ReminderNotFoundException extends RuntimeException {
+    public ReminderNotFoundException(String message) {
+        super(message);
+    }
+} 

--- a/src/main/java/info/reinput/reinput_notification_service/notification/infra/ReminderScheduleRepository.java
+++ b/src/main/java/info/reinput/reinput_notification_service/notification/infra/ReminderScheduleRepository.java
@@ -3,7 +3,10 @@ package info.reinput.reinput_notification_service.notification.infra;
 import info.reinput.reinput_notification_service.notification.domain.ReminderSchedule;
 import info.reinput.reinput_notification_service.notification.domain.Reminder;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 public interface ReminderScheduleRepository extends JpaRepository<ReminderSchedule, Long> {
     void deleteAllByReminder(Reminder reminder);
+
+    List<ReminderSchedule> findByReminder(Reminder reminder);
 } 

--- a/src/main/java/info/reinput/reinput_notification_service/notification/presentation/ReminderController.java
+++ b/src/main/java/info/reinput/reinput_notification_service/notification/presentation/ReminderController.java
@@ -3,6 +3,7 @@ package info.reinput.reinput_notification_service.notification.presentation;
 import info.reinput.reinput_notification_service.notification.application.ReminderService;
 import info.reinput.reinput_notification_service.notification.presentation.dto.req.ReminderCreateReq;
 import info.reinput.reinput_notification_service.notification.presentation.dto.res.ReminderCreateRes;
+import info.reinput.reinput_notification_service.notification.presentation.dto.res.ReminderDetailRes;
 import info.reinput.reinput_notification_service.global.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -32,7 +33,12 @@ public class ReminderController {
                     제약사항:
                     1. isActive가 true인 경우 반드시 types가 필요하며, 비어있을 수 없습니다.
                     2. isActive가 false인 경우 types가 포함되어서는 안됩니다.
-                    3. types에는 ReminderType에 정의된 값만 사용 가능합니다.
+                    3. types에는 다음과 같은 ReminderType 값만 사용 가능합니다:
+                       - Monthly_12: 매월 12일 알림
+                       - Monthly_31: 매월 31일 알림
+                       - Weekly_Mon: 매주 월요일 알림
+                       - Weekly_Fri: 매주 금요일 알림
+                       - Recommended: 망각곡선 기반 추천 알림
                     """,
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     content = @Content(
@@ -91,7 +97,7 @@ public class ReminderController {
                                             }
                                             """),
                                     @ExampleObject(
-                                            name = "500 오류: 존재하지 않는 ReminderType",
+                                            name = "400 오류: 유효하지 않은 ReminderType",
                                             value = """
                                             {
                                               "insightId": 7,
@@ -125,23 +131,34 @@ public class ReminderController {
                                     요청이 유효하지 않은 경우:
                                     - isActive가 true인데 types가 없거나 비어있는 경우
                                     - isActive가 false인데 types가 포함된 경우
-                                    - 존재하지 않는 ReminderType이 포함된 경우
+                                    - 유효하지 않은 ReminderType이 포함된 경우 (예: "Invalid_Type")
                                     """,
                             content = @Content(
                                     mediaType = "application/json",
                                     schema = @Schema(implementation = ErrorResponse.class),
-                                    examples = @ExampleObject(
+                                    examples = {
+                                        @ExampleObject(
+                                            name = "활성화 상태에서 types 누락",
                                             value = """
                                             {
                                               "message": "활성화된 리마인더는 반드시 알림 타입을 포함해야 합니다.",
                                               "code": "INVALID_REMINDER_REQUEST"
                                             }
+                                            """),
+                                        @ExampleObject(
+                                            name = "유효하지 않은 ReminderType",
+                                            value = """
+                                            {
+                                              "message": "유효하지 않은 ReminderType입니다: Invalid_Type",
+                                              "code": "INVALID_REMINDER_REQUEST"
+                                            }
                                             """)
+                                    }
                             )
                     ),
                     @ApiResponse(
                             responseCode = "500",
-                            description = "서버 내부 오류 (주로 유효하지 않은 ReminderType이 포함된 경우)",
+                            description = "서버 내부 오류 (데이터베이스 오류 등 예외적인 경우)",
                             content = @Content(
                                     mediaType = "application/json",
                                     schema = @Schema(implementation = ErrorResponse.class),
@@ -159,6 +176,50 @@ public class ReminderController {
     @PatchMapping
     public ResponseEntity<ReminderCreateRes> createReminder(@RequestBody ReminderCreateReq request) {
         ReminderCreateRes response = reminderService.createReminder(request);
+        return ResponseEntity.ok(response);
+    }
+    
+    @Operation(
+            summary = "리마인더 조회",
+            description = "insightId를 이용하여 리마인더를 조회합니다. 활성화된 리마인더인 경우 알림 스케줄의 타입도 포함됩니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "리마인더 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ReminderDetailRes.class),
+                                    examples = @ExampleObject(
+                                            value = """
+                                            {
+                                              "reminderId": 1,
+                                              "insightId": 1,
+                                              "isActive": true,
+                                              "types": ["Monthly_12", "Monthly_31"]
+                                            }
+                                            """)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "리마인더를 찾을 수 없는 경우",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ErrorResponse.class),
+                                    examples = @ExampleObject(
+                                            value = """
+                                            {
+                                              "message": "해당 insightId에 대한 리마인더를 찾을 수 없습니다: 1",
+                                              "code": "REMINDER_NOT_FOUND"
+                                            }
+                                            """)
+                            )
+                    )
+            }
+    )
+    @GetMapping
+    public ResponseEntity<ReminderDetailRes> getReminder(@RequestParam("insightId") Long insightId) {
+        ReminderDetailRes response = reminderService.getReminderDetail(insightId);
         return ResponseEntity.ok(response);
     }
 } 

--- a/src/main/java/info/reinput/reinput_notification_service/notification/presentation/dto/res/ReminderDetailRes.java
+++ b/src/main/java/info/reinput/reinput_notification_service/notification/presentation/dto/res/ReminderDetailRes.java
@@ -1,0 +1,27 @@
+package info.reinput.reinput_notification_service.notification.presentation.dto.res;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import info.reinput.reinput_notification_service.notification.domain.ReminderType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ReminderDetailRes {
+    private Long reminderId;
+    private Long insightId;
+    
+    @JsonProperty("isActive")
+    private boolean isActive;
+    
+    // isActive가 true인 경우에만 포함, 그렇지 않으면 null/빈 리스트
+    private List<ReminderType> types;
+    
+    @JsonGetter("isActive")
+    public boolean isActive() {
+        return isActive;
+    }
+} 


### PR DESCRIPTION
- Implement getReminderDetail method in ReminderService to fetch reminder details by insightId
- Add ReminderDetailRes DTO to support detailed reminder response
- Create ReminderNotFoundException and InvalidReminderTypeException for specific error scenarios
- Update GlobalExceptionHandler to handle new custom exceptions
- Add validation for ReminderType in ReminderServiceImpl
- Extend ReminderController with GET endpoint for reminder retrieval
- Update Swagger documentation for new reminder detail retrieval functionality

close [RE-212]

[RE-212]: https://reinput.atlassian.net/browse/RE-212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ