### PR TITLE
RE-218 feat: add reminder deletion functionality with associated schedule cleanup

### DIFF
--- a/src/main/java/info/reinput/reinput_notification_service/notification/application/ReminderService.java
+++ b/src/main/java/info/reinput/reinput_notification_service/notification/application/ReminderService.java
@@ -8,4 +8,6 @@ public interface ReminderService {
     ReminderCreateRes createReminder(ReminderCreateReq request);
     
     ReminderDetailRes getReminderDetail(Long insightId);
+    
+    void deleteReminder(Long insightId);
 } 

--- a/src/main/java/info/reinput/reinput_notification_service/notification/exception/ReminderScheduleDeletionException.java
+++ b/src/main/java/info/reinput/reinput_notification_service/notification/exception/ReminderScheduleDeletionException.java
@@ -1,0 +1,7 @@
+package info.reinput.reinput_notification_service.notification.exception;
+
+public class ReminderScheduleDeletionException extends RuntimeException {
+    public ReminderScheduleDeletionException(String message) {
+        super(message);
+    }
+} 

--- a/src/main/java/info/reinput/reinput_notification_service/notification/presentation/ReminderController.java
+++ b/src/main/java/info/reinput/reinput_notification_service/notification/presentation/ReminderController.java
@@ -222,4 +222,36 @@ public class ReminderController {
         ReminderDetailRes response = reminderService.getReminderDetail(insightId);
         return ResponseEntity.ok(response);
     }
+
+    @Operation(
+            summary = "리마인더 삭제",
+            description = "해당 insightId에 해당하는 리마인더와 연결된 리마인더 스케줄을 삭제합니다. 스케줄 삭제가 성공적인 경우에만 리마인더를 삭제합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "204",
+                            description = "리마인더 삭제 성공 (No Content)"
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "해당 insightId에 대한 리마인더를 찾을 수 없는 경우",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ErrorResponse.class)
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "리마인더 스케줄 삭제 실패 또는 서버 내부 오류",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ErrorResponse.class)
+                            )
+                    )
+            }
+    )
+    @DeleteMapping
+    public ResponseEntity<Void> deleteReminder(@RequestParam("insightId") Long insightId) {
+        reminderService.deleteReminder(insightId);
+        return ResponseEntity.noContent().build();
+    }
 } 


### PR DESCRIPTION

- Implement deleteReminder method in ReminderService to delete reminders by insightId
- Add ReminderScheduleDeletionException for handling schedule deletion failures
- Create new DeleteMapping endpoint in ReminderController for reminder deletion
- Ensure complete deletion of reminder and its associated schedules
- Add comprehensive Swagger documentation for the deletion endpoint

close [RE-218]

[RE-218]: https://reinput.atlassian.net/browse/RE-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ